### PR TITLE
use copy() to change actual storage order in memory

### DIFF
--- a/libmf/mf.py
+++ b/libmf/mf.py
@@ -182,5 +182,5 @@ def generate_test_data(xs, ys, k, indices_only=False):
     rx = np.random.random_integers(0, xs, k)
     ry = np.random.random_integers(0, ys, k)
     rv = np.random.rand(k)
-    return np.vstack((rx, ry, rv)).transpose() if not indices_only else np.vstack((rx,ry)).transpose()
+    return np.vstack((rx, ry, rv)).transpose().copy() if not indices_only else np.vstack((rx,ry)).transpose().copy()
 

--- a/src_cpp/libmf_interface.cpp
+++ b/src_cpp/libmf_interface.cpp
@@ -26,9 +26,9 @@ mf::mf_problem prob_from_sparse(const int nnx, float *X){
     for(i=0; i < prob.nnz; i++){
         mf::mf_node N;
         
-        N.u = (int)X[i];
-        N.v = (int)X[i + 1 * prob.nnz];
-        N.r = X[i + 2 * prob.nnz];
+        N.u = (int)X[i * 3];
+        N.v = (int)X[i * 3 + 1];
+        N.r = X[i * 3 + 2];
         if(N.u+1 > prob.m)
             prob.m = N.u+1;
         if(N.v+1 > prob.n)


### PR DESCRIPTION
Use copy() to change actual storage order in memory.
Avoid jumping in memory when iterate the float array.
Since transpose() doesn't change the order in which data is stored, the C++ code still reads the data created in vstack() order.
PS: I also tried np.matrix(list(zip(u,v,r))). But the vstack() + transpose() approach is faster.